### PR TITLE
Android 3755/publish to artifactory gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,13 @@
 buildscript {
     repositories {
-        google()
         jcenter()
+        maven { url 'https://maven.google.com' }
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.5.4"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jul 20 01:49:32 CDT 2018
+#Tue Aug 18 16:38:25 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip

--- a/library-extension-rx/build.gradle
+++ b/library-extension-rx/build.gradle
@@ -20,9 +20,8 @@ android {
         }
     }
 
-    // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
-    libraryVariants.all {
-        it.generateBuildConfig.enabled = false
+    buildFeatures {
+        buildConfig = false
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,5 +1,12 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'com.jfrog.artifactory'
+apply plugin: 'maven-publish'
+
+def packageName = 'com.instacart.library'
+def artifactoryRepositoryVariant
+version = versionName
+group = 'com.github.instacart'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -12,6 +19,8 @@ android {
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
+        archivesBaseName = "truetime"
+
     }
     buildTypes {
         release {
@@ -20,9 +29,36 @@ android {
         }
     }
 
-    // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
-    libraryVariants.all {
-        it.generateBuildConfig.enabled = false
+    buildFeatures {
+        buildConfig = false
+    }
+
+    libraryVariants.all { variant ->
+        println "variant: " + variant.baseName
+        variant.outputs.all { output ->
+            if (variant.getPackageLibraryProvider().get() != null) {
+                outputFileName = "${archivesBaseName}-${version}.aar"
+                println "outputFileName: " + outputFileName
+            }
+        }
+    }
+
+    // workaround for https://github.com/gradle/gradle/issues/8328
+    // The name is properly built and reported in the script above, but the output file names are simply
+    // truetime-debug.aar and truetime-release.aar
+    afterEvaluate {
+        def debugFile = file("$buildDir/outputs/aar/${archivesBaseName}-debug.aar")
+        tasks.named("assembleDebug").configure {
+            doLast {
+                debugFile.renameTo("$buildDir/outputs/aar/${archivesBaseName}-${version}.aar")
+            }
+        }
+        def releaseFile = file("$buildDir/outputs/aar/${archivesBaseName}-release.aar")
+        tasks.named("assembleRelease").configure {
+            doLast {
+                releaseFile.renameTo("$buildDir/outputs/aar/${archivesBaseName}-${version}.aar")
+            }
+        }
     }
 }
 
@@ -30,4 +66,34 @@ dependencies {
 
 }
 
-group='com.github.instacart'
+publishing {
+    repositories {
+        maven {
+            credentials {
+                username "${artifactory_user}"
+                password "${artifactory_password}"
+            }
+
+            if (artifactory_variant == "release") {
+                version = version + "-WND"
+                artifactoryRepositoryVariant = "release"
+            } else {
+                version = version + "-SNAPSHOT"
+                artifactoryRepositoryVariant = "snapshot"
+            }
+
+            url "${artifactory_contextUrl}/libs-${artifactoryRepositoryVariant}-local"
+        }
+    }
+    publications {
+        aar(MavenPublication) {
+            groupId = packageName
+            artifactId = archivesBaseName
+
+            def targetFile = "$buildDir/outputs/aar/${archivesBaseName}-${version}.aar"
+            println "publishing: " + targetFile
+            // Tell maven to prepare the generated "*.aar" file for publishing
+            artifact(targetFile)
+        }
+    }
+}


### PR DESCRIPTION
- updated Android Gradle plugin to version 4.0.1
- updated Gradle wrapper to version 6.6
- resolved TODO - the original code was using a deprecated method, the linked issue has been resolved in the meantime - used the new feature - no warning about deprecated methods
- added configuration for publishing
    - the debug variant is published to snapshot
    - the release variant is published to release